### PR TITLE
improve fpc (unix/windows) compatibility

### DIFF
--- a/Demo/test.dpr
+++ b/Demo/test.dpr
@@ -5,7 +5,10 @@ program test;
 {$ENDIF}
 
 {$ASSERTIONS ON}
-{$APPTYPE CONSOLE}
+
+{$IFDEF WINDOWS}
+  {$APPTYPE CONSOLE}
+{$ENDIF}
 
 {.$R *.res}
 

--- a/msgpack.pas
+++ b/msgpack.pas
@@ -21,13 +21,16 @@
 
 unit msgpack;
 
+{$IFDEF FPC}
+  {$MODE DELPHI}
+{$ENDIF}
+
 interface
 
 uses
   SysUtils, Classes;
 
 {$IFDEF FPC}
-  {$MODE Delphi}
   {$DEFINE HAVE_INLINE}
 {$ELSE}
   {$WARN UNSAFE_CAST OFF}


### PR DESCRIPTION
- APPTYPE CONSOLE is a windows only directive           c7654ee
- MODE DELPHI must be global            6fcb1d3
